### PR TITLE
Add Docker support and entrypoint script; update handler return types   @abutbul

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+*.o
+*.a
+magicka
+utils/*/obj
+utils/*/*.o
+deps/**/obj
+deps/**/objs-*
+deps/**/libs-*
+.git
+.github
+Dockerfile
+*.swp
+*.tmp
+logs
+data

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "lualib.h": "c",
+        "lua.h": "c"
+    }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+## Multi-stage build for MagickaBBS with WWW support
+FROM debian:stable-slim AS build
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    make \
+    ca-certificates \
+    libsqlite3-dev \
+    libssl-dev \
+    libssh-dev \
+    libmicrohttpd-dev \
+    zlib1g-dev \
+    libreadline-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . .
+
+# Build with WWW enabled (Makefile.linux.WWW sets -DENABLE_WWW)
+RUN make -f Makefile.linux.WWW magicka
+
+## Runtime image
+FROM debian:stable-slim AS runtime
+LABEL org.opencontainers.image.title="MagickaBBS" \
+      org.opencontainers.image.source="https://github.com/abutbul/MagickaBBS" \
+      org.opencontainers.image.description="Classic style BBS with optional web/SSH frontends" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    DATA_DIR=/data \
+    ENABLE_WWW=true \
+    ENABLE_SSH=false \
+    ENABLE_FORK=false
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsqlite3-0 \
+    libssl3 \
+    libssh-4 \
+    libmicrohttpd12 \
+    zlib1g \
+    libreadline8 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Create app user
+RUN useradd -r -m -d /opt/magicka magicka
+
+WORKDIR /opt/magicka
+
+# Copy binary
+COPY --from=build /src/magicka /usr/local/bin/magicka
+
+# Copy defaults (keep under /opt/magicka for seeding the data volume)
+COPY config_default ./config_default
+COPY ansis_default ./ansis_default
+COPY www ./www_default
+COPY magicka.strings ./magicka.strings
+
+# Entry script
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+VOLUME ["/data"]
+
+# Expose typical ports (can be toggled via config):
+# 2023 Telnet, 2024 SSH, 8080 HTTP, 6667 MagiChat (IRC-like), 2027 UDP Broadcast
+EXPOSE 2023 2024 8080 6667 2027/udp
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["magicka"]

--- a/bbs.h
+++ b/bbs.h
@@ -318,7 +318,7 @@ extern void chomp(char *string);
 extern void www_init();
 extern void *www_logger(void * cls, const char * uri, struct MHD_Connection *con);
 extern void www_request_completed(void *cls, struct MHD_Connection *connection, void **con_cls, enum MHD_RequestTerminationCode toe);
-extern int www_handler(void * cls, struct MHD_Connection * connection, const char * url, const char * method, const char * version, const char * upload_data, size_t * upload_data_size, void ** ptr);
+extern enum MHD_Result www_handler(void * cls, struct MHD_Connection * connection, const char * url, const char * method, const char * version, const char * upload_data, size_t * upload_data_size, void ** ptr);
 extern char *www_email_summary(struct user_record *user);
 extern char *www_email_display(struct user_record *user, int email);
 extern int www_send_email(struct user_record *user, char *recipient, char *subject, char *body);

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,89 @@
+#!/bin/sh
+set -e
+
+# Ensure data directory exists and owned (even if running root)
+mkdir -p /data || true
+if id magicka >/dev/null 2>&1; then
+  chown -R magicka:magicka /data 2>/dev/null || true
+fi
+
+DATA_DIR="${DATA_DIR:-/data}"
+CONFIG_DIR="$DATA_DIR/config"
+LOG_DIR="$DATA_DIR/logs"
+WWW_DIR="$DATA_DIR/www"
+ANSIS_DIR="$DATA_DIR/ansis"
+MENUS_DIR="$DATA_DIR/menus"
+SCRIPTS_DIR="$DATA_DIR/scripts"
+
+seed_file_structure() {
+  mkdir -p "$CONFIG_DIR" "$LOG_DIR" "$WWW_DIR" "$ANSIS_DIR" "$MENUS_DIR" "$SCRIPTS_DIR"
+
+  # Seed base config if missing
+  if [ ! -f "$CONFIG_DIR/bbs.ini" ]; then
+    echo "Seeding default configuration..." >&2
+    cp -r /opt/magicka/config_default/* "$CONFIG_DIR/" 2>/dev/null || true
+    # Adjust absolute paths from original developer environment to container paths
+    sed -i "s|/home/andrew/MagickaBBS|$DATA_DIR|g" "$CONFIG_DIR/bbs.ini" || true
+  fi
+
+  # Seed ANSI files if empty
+  if [ "$(ls -A $ANSIS_DIR 2>/dev/null | wc -l)" = "0" ]; then
+    cp -r /opt/magicka/ansis_default/* "$ANSIS_DIR/" 2>/dev/null || true
+  fi
+
+  # Seed WWW templates
+  if [ "$(ls -A $WWW_DIR 2>/dev/null | wc -l)" = "0" ]; then
+    cp -r /opt/magicka/www_default/* "$WWW_DIR/" 2>/dev/null || true
+  fi
+}
+
+tune_config() {
+  ini="$CONFIG_DIR/bbs.ini"
+  [ -f "$ini" ] || return 0
+
+  # Ensure base paths reference DATA_DIR
+  sed -i "s|^Config Path = .*|Config Path = $CONFIG_DIR|" "$ini" || true
+  sed -i "s|^WWW Path = .*|WWW Path = $WWW_DIR|" "$ini" || true
+  sed -i "s|^String File = .*|String File = /opt/magicka/magicka.strings|" "$ini" || true
+  sed -i "s|^PID File = .*|PID File = $DATA_DIR/magicka.pid|" "$ini" || true
+  sed -i "s|^ANSI Path = .*|ANSI Path = $ANSIS_DIR|" "$ini" || true
+  sed -i "s|^BBS Path = .*|BBS Path = $DATA_DIR|" "$ini" || true
+  sed -i "s|^Log Path = .*|Log Path = $LOG_DIR|" "$ini" || true
+  sed -i "s|^Script Path = .*|Script Path = $SCRIPTS_DIR|" "$ini" || true
+  sed -i "s|^Menu Path = .*|Menu Path = $MENUS_DIR|" "$ini" || true
+
+  if [ "${ENABLE_WWW}" = "true" ]; then
+    sed -i 's/^Enable WWW = .*/Enable WWW = true/' "$ini" || true
+  else
+    sed -i 's/^Enable WWW = .*/Enable WWW = false/' "$ini" || true
+  fi
+
+  if [ "${ENABLE_SSH}" = "true" ]; then
+    sed -i 's/^Enable SSH = .*/Enable SSH = true/' "$ini" || true
+  else
+    sed -i 's/^Enable SSH = .*/Enable SSH = false/' "$ini" || true
+  fi
+
+  if [ "${ENABLE_FORK}" = "true" ]; then
+    sed -i 's/^Fork = .*/Fork = true/' "$ini" || true
+  else
+    sed -i 's/^Fork = .*/Fork = false/' "$ini" || true
+  fi
+  # Ensure included config file references keep config/ prefix (app expects relative path)
+  for f in localmail.ini illusionnet.ini filesgen.ini; do
+    sed -i "s/\(= \)${f}$/\1config\/${f}/" "$ini" || true
+  done
+}
+
+seed_file_structure
+tune_config
+
+if [ "$1" = "magicka" ] && [ $# -eq 1 ]; then
+  set -- magicka "$CONFIG_DIR/bbs.ini"
+fi
+
+# Run from DATA_DIR so relative 'config/...' paths resolve
+cd "$DATA_DIR"
+
+echo "Starting MagickaBBS with: $@" >&2
+exec "$@"

--- a/lua_glue.c
+++ b/lua_glue.c
@@ -2,6 +2,7 @@
 #include "bbs.h"
 #include "lua/lua.h"
 #include "lua/lauxlib.h"
+#include "lua/lualib.h"
 
 extern int mynode;
 extern struct bbs_config conf;

--- a/www.c
+++ b/www.c
@@ -85,7 +85,7 @@ void www_request_completed(void *cls, struct MHD_Connection *connection, void **
 	free(con_info);
 }
 
-static int iterate_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key, const char *filename, const char *content_type, const char *transfer_encoding, const char *data, uint64_t off, size_t size) {
+static enum MHD_Result iterate_post (void *coninfo_cls, enum MHD_ValueKind kind, const char *key, const char *filename, const char *content_type, const char *transfer_encoding, const char *data, uint64_t off, size_t size) {
 	struct connection_info_s *con_info = coninfo_cls;
 
 	int i;
@@ -365,7 +365,7 @@ struct user_record *www_auth_ok(struct MHD_Connection *connection, const char *u
 	return NULL;
 }
 
-int www_handler(void * cls, struct MHD_Connection * connection, const char * url, const char * method, const char * version, const char * upload_data, size_t * upload_data_size, void ** ptr) {
+enum MHD_Result www_handler(void * cls, struct MHD_Connection * connection, const char * url, const char * method, const char * version, const char * upload_data, size_t * upload_data_size, void ** ptr) {
 	struct MHD_Response *response;
 	
 	int ret;
@@ -418,7 +418,7 @@ int www_handler(void * cls, struct MHD_Connection * connection, const char * url
 			return MHD_YES;
 		}
 	} else {
-		return MHD_NO;
+			return MHD_NO;
 	}
 	
 	con_inf = *ptr;


### PR DESCRIPTION
Need www_handler signature to return enum MHD_Result for newer libmicrohttpd; patch signature and return values. Searching for MHD_queue_response returns int is fine; we return MHD_YES.

Patch www_handler to use enum MHD_Result and adjust return statements to MHD_YES/MHD_NO.

Updating declaration in bbs.h to match new signature and adjusting return type from int to enum MHD_Result everywhere.

Need to include lua/lualib.h for luaL_openlibs prototype. Patch includes.

Updating iterate_post signature in [www.c](http://www.c/) to match new libmicrohttpd MHD_PostDataIterator prototype.